### PR TITLE
Copy .json files in addition to .clj files to bazel sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .ijwb/
 bazel-*
-
+.DS_Store

--- a/rules.bzl
+++ b/rules.bzl
@@ -51,7 +51,7 @@ clojure_repl = rule(
 clojure_test = rule(
     doc = "Runs clojure.test for given sources.",
     attrs = {
-        "srcs": attr.label_list(mandatory = True, allow_empty = False, allow_files = [".clj"], doc = "clj source files with test cases."),
+        "srcs": attr.label_list(mandatory = True, allow_empty = False, allow_files = [".clj", ".json"], doc = "clj source files with test cases and resource files."),
         "deps": attr.label_list(default = [], providers = [JavaInfo], doc = "Libraries to link into this library."),
     },
     test = True,

--- a/scripts/test.clj
+++ b/scripts/test.clj
@@ -1,5 +1,6 @@
 (require '[clojure.test :as test])
 (require '[clojure.java.io :as io])
+(require '[clojure.string :as cs])
 (import (java.io PushbackReader))
 
 (defn ns-symbol [file]
@@ -12,7 +13,7 @@
 (defn ns-path [file]
   (-> file ns-symbol name (.replace \- \_) (.replace \. \/) (str ".clj")))
 
-(def sources (map io/file *command-line-args*))
+(def sources (map io/file (filter (fn [file] (cs/ends-with? file ".clj")) *command-line-args*)))
 
 (doseq [source sources]
   (load-file (.getCanonicalPath source)))


### PR DESCRIPTION
This is probably not the best way to do this, but I couldn’t find another more appropriate way to do it via the “resource” or “data” attribute. I was able to add an additional attribute, but I couldn’t get bazel to copy the json files to the sandbox like it does for “srcs” attribute.

I submitted a feature request to the original repo: https://github.com/simuons/rules_clojure/issues/60