### PR TITLE
fix: remove deprecated usages

### DIFF
--- a/rules/binary.bzl
+++ b/rules/binary.bzl
@@ -3,7 +3,7 @@ def clojure_binary_impl(ctx):
 
     deps = depset(
         direct = toolchain.files.runtime,
-        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps],
+        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps],
     )
 
     ctx.actions.write(

--- a/rules/compile.bzl
+++ b/rules/compile.bzl
@@ -6,7 +6,7 @@ def clojure_java_library_impl(ctx):
 
     deps = depset(
         direct = toolchain.files.runtime,
-        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps],
+        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps],
     )
 
     cmd = """

--- a/rules/repl.bzl
+++ b/rules/repl.bzl
@@ -3,7 +3,7 @@ def clojure_repl_impl(ctx):
 
     deps = depset(
         direct = toolchain.files.runtime,
-        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps],
+        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps],
     )
 
     ctx.actions.write(

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -3,7 +3,7 @@ def clojure_test_impl(ctx):
 
     deps = depset(
         direct = toolchain.files.runtime,
-        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps],
+        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps],
     )
 
     ctx.actions.write(


### PR DESCRIPTION
Remove the deprecated usages of `transitive_runtime_deps` as per https://fivetran.atlassian.net/browse/RD-634222 https://fivetran.atlassian.net/browse/RD-638509

After the changes the bazel sync with v7 is working fine.

Before change
<img width="2556" alt="Screenshot 2024-04-04 at 3 17 12 PM" src="https://github.com/fivetran/rules_clojure/assets/59430442/2e166f25-510e-4e43-89f2-9ee5b65cc307">

After change
<img width="2251" alt="Screenshot 2024-04-04 at 3 15 00 PM" src="https://github.com/fivetran/rules_clojure/assets/59430442/1d52383d-3d80-46c4-9671-7339860eaa3a">

