### PR TITLE
Use `compile_time_jars` instead of `runtime_jars` for Clojure compilation

### DIFF
--- a/rules/compile.bzl
+++ b/rules/compile.bzl
@@ -6,10 +6,6 @@ def clojure_java_library_impl(ctx):
     classes = ctx.actions.declare_directory("%s.classes" % ctx.label.name)
     jar = ctx.actions.declare_file("%s.jar" % ctx.label.name)
 
-    # Use compile_time_jars instead of runtime_jars to avoid JaCoCo-instrumented dependencies
-    # during compilation. During coverage builds, runtime_jars are instrumented but
-    # compile_time_jars are not, which prevents ClassNotFoundException when Clojure macros
-    # (like gen-class) try to load classes at compile-time.
     deps = depset(
         direct = toolchain.files.runtime,
         transitive = [dep[JavaInfo].transitive_compile_time_jars for dep in ctx.attr.deps],

--- a/rules/compile.bzl
+++ b/rules/compile.bzl
@@ -6,9 +6,13 @@ def clojure_java_library_impl(ctx):
     classes = ctx.actions.declare_directory("%s.classes" % ctx.label.name)
     jar = ctx.actions.declare_file("%s.jar" % ctx.label.name)
 
+    # Use compile_time_jars instead of runtime_jars to avoid JaCoCo-instrumented dependencies
+    # during compilation. During coverage builds, runtime_jars are instrumented but
+    # compile_time_jars are not, which prevents ClassNotFoundException when Clojure macros
+    # (like gen-class) try to load classes at compile-time.
     deps = depset(
         direct = toolchain.files.runtime,
-        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps],
+        transitive = [dep[JavaInfo].transitive_compile_time_jars for dep in ctx.attr.deps],
     )
 
     cmd = """


### PR DESCRIPTION
Clojure compilation was failing during bazel coverage builds with:
`ClassNotFoundException: org.jacoco.agent.rt.internal_*.Offline`

**Root cause**
The `clojure_java_library` rule incorrectly used `transitive_runtime_jars` for the compilation classpath. During coverage builds:
- runtime_jars: Full classes + JaCoCo bytecode instrumentation
- compile_time_jars: Full classes without instrumentation

When Clojure's macro expansion loaded instrumented classes at compile-time, the instrumented bytecode referenced JaCoCo agent classes that aren't available during compilation (only at test runtime).