### PR TITLE
fix: Remove invalid 'maven' repository import from use_repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "rules_java", version = "8.16.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
 
 rules_clojure_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-use_repo(rules_clojure_maven, "maven", "rules_clojure_maven")
+use_repo(rules_clojure_maven, "rules_clojure_maven")
 rules_clojure_maven.install(
     name = "rules_clojure_maven",
     artifacts = [


### PR DESCRIPTION
## Summary
- Removes the invalid `"maven"` repository import from `use_repo()` in MODULE.bazel
- The maven extension only generates repositories based on the `name` parameter in `maven.install()`

## Problem
The maven extension in `rules_jvm_external` does not generate a repository named `"maven"` - it only generates repositories based on the `name` parameter passed to `maven.install()`. In our case, that's `"rules_clojure_maven"`.

This issue was previously hidden but is now exposed when using newer Bazel dependencies (e.g., `contrib_rules_jvm` 0.31.0 with `bazel_lib` 3.0.0) that enforce stricter validation of module extensions.

## Error Fixed
```
ERROR: module extension @@rules_jvm_external+//:extensions.bzl%maven does not generate repository "maven", yet it is imported as "maven" in the usage at @@rules_clojure+//:MODULE.bazel:9:36
```

## Changes
Changed line 10 from:
```bazel
use_repo(rules_clojure_maven, "maven", "rules_clojure_maven")
```

To:
```bazel
use_repo(rules_clojure_maven, "rules_clojure_maven")
```

## Testing
This fix is required for compatibility with newer versions of Bazel tooling used in the Fivetran engineering repository when preparing for Java 25 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)